### PR TITLE
fix: preserve CRLF line endings in marker strategy (GH #19)

### DIFF
--- a/internal/template/marker.go
+++ b/internal/template/marker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"sort"
 )
 
 var (
@@ -13,8 +14,7 @@ var (
 
 type section struct {
 	name    string
-	content []byte // content between BEGIN and END markers, inclusive of markers + surrounding newline
-	inner   []byte // content between BEGIN and END markers, exclusive of markers and their trailing newline
+	content []byte // content from the BEGIN marker through the END marker, inclusive of both markers
 }
 
 // detectEOL returns the dominant line ending of data — CRLF if \r\n occurrences
@@ -42,74 +42,89 @@ func normalizeEOL(data, target []byte) []byte {
 	return bytes.ReplaceAll(normalized, lf, target)
 }
 
+// markerKind tags a BEGIN or END marker match during extractSections'
+// ordered scan.
+type markerKind int
+
+const (
+	markerBegin markerKind = iota
+	markerEnd
+)
+
+type markerMatch struct {
+	kind  markerKind
+	name  string
+	start int // byte offset of the full marker (e.g. '<' in "<!--")
+	end   int // byte offset one past the closing '>'
+}
+
 // extractSections finds all STEERSPEC:BEGIN/END marker pairs in data by
-// byte offsets. Returns an error on nested, unmatched, or mismatched markers.
+// byte offsets. Returns an error on nested, unmatched, or mismatched markers,
+// always pointing at the specific offending marker by scanning them in order.
 //
-// We match by byte offset rather than line-splitting so mixed line endings
-// (e.g. a previously LF-rendered section inside a now-CRLF file during the
-// CRLF-preservation rollout) don't break marker detection.
+// Matching by byte offset rather than line-splitting makes this robust to
+// mixed line endings (e.g. a previously LF-rendered section living inside a
+// now-CRLF file during the CRLF-preservation rollout).
 func extractSections(data []byte) ([]section, error) {
-	begins := markerBeginRe.FindAllSubmatchIndex(data, -1)
-	ends := markerEndRe.FindAllSubmatchIndex(data, -1)
+	matches := collectMarkers(data)
 
-	if len(begins) != len(ends) {
-		if len(begins) > len(ends) {
-			name := string(data[begins[len(ends)][2]:begins[len(ends)][3]])
-			return nil, fmt.Errorf("unclosed STEERSPEC:BEGIN marker %q", name)
+	var sections []section
+	// Stack depth = 1 because nesting is disallowed; the extra state just
+	// lets us report the nesting case with the correct outer/inner names.
+	var open *markerMatch
+	for i := range matches {
+		m := &matches[i]
+		switch m.kind {
+		case markerBegin:
+			if open != nil {
+				return nil, fmt.Errorf("nested STEERSPEC:BEGIN marker %q inside %q", m.name, open.name)
+			}
+			open = m
+		case markerEnd:
+			if open == nil {
+				return nil, fmt.Errorf("STEERSPEC:END marker %q without matching BEGIN", m.name)
+			}
+			if open.name != m.name {
+				return nil, fmt.Errorf("STEERSPEC:END marker %q does not match BEGIN %q", m.name, open.name)
+			}
+			content := append([]byte(nil), data[open.start:m.end]...)
+			sections = append(sections, section{name: open.name, content: content})
+			open = nil
 		}
-		name := string(data[ends[len(begins)][2]:ends[len(begins)][3]])
-		return nil, fmt.Errorf("STEERSPEC:END marker %q without matching BEGIN", name)
 	}
-
-	sections := make([]section, 0, len(begins))
-	for i, b := range begins {
-		e := ends[i]
-		if e[0] < b[1] {
-			// END appears before BEGIN: unmatched END.
-			name := string(data[e[2]:e[3]])
-			return nil, fmt.Errorf("STEERSPEC:END marker %q without matching BEGIN", name)
-		}
-		if i+1 < len(begins) && begins[i+1][0] < e[0] {
-			// A BEGIN appears before the current END: nested.
-			inner := string(data[begins[i+1][2]:begins[i+1][3]])
-			outer := string(data[b[2]:b[3]])
-			return nil, fmt.Errorf("nested STEERSPEC:BEGIN marker %q inside %q", inner, outer)
-		}
-
-		beginName := string(data[b[2]:b[3]])
-		endName := string(data[e[2]:e[3]])
-		if beginName != endName {
-			return nil, fmt.Errorf("STEERSPEC:END marker %q does not match BEGIN %q", endName, beginName)
-		}
-
-		innerStart, innerEnd := b[1], e[0]
-		inner := trimSurroundingNewline(data[innerStart:innerEnd])
-		content := data[b[0]:e[1]]
-
-		sections = append(sections, section{
-			name:    beginName,
-			inner:   append([]byte(nil), inner...),
-			content: append([]byte(nil), content...),
-		})
+	if open != nil {
+		return nil, fmt.Errorf("unclosed STEERSPEC:BEGIN marker %q", open.name)
 	}
 	return sections, nil
 }
 
-// trimSurroundingNewline strips one leading and one trailing newline (CRLF or
-// LF) from inner marker content so that a round-trip extract/insert doesn't
-// accumulate blank lines across renders.
-func trimSurroundingNewline(b []byte) []byte {
-	if bytes.HasPrefix(b, []byte("\r\n")) {
-		b = b[2:]
-	} else if bytes.HasPrefix(b, []byte("\n")) {
-		b = b[1:]
+// collectMarkers returns every BEGIN and END marker occurrence in data,
+// sorted by their byte offset so the caller can walk them in source order.
+func collectMarkers(data []byte) []markerMatch {
+	begins := markerBeginRe.FindAllSubmatchIndex(data, -1)
+	ends := markerEndRe.FindAllSubmatchIndex(data, -1)
+
+	matches := make([]markerMatch, 0, len(begins)+len(ends))
+	for _, b := range begins {
+		matches = append(matches, markerMatch{
+			kind:  markerBegin,
+			name:  string(data[b[2]:b[3]]),
+			start: b[0],
+			end:   b[1],
+		})
 	}
-	if bytes.HasSuffix(b, []byte("\r\n")) {
-		b = b[:len(b)-2]
-	} else if bytes.HasSuffix(b, []byte("\n")) {
-		b = b[:len(b)-1]
+	for _, e := range ends {
+		matches = append(matches, markerMatch{
+			kind:  markerEnd,
+			name:  string(data[e[2]:e[3]]),
+			start: e[0],
+			end:   e[1],
+		})
 	}
-	return b
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].start < matches[j].start
+	})
+	return matches
 }
 
 func renderMarker(templateContent, existingContent []byte) ([]byte, error) {

--- a/internal/template/marker.go
+++ b/internal/template/marker.go
@@ -13,67 +13,117 @@ var (
 
 type section struct {
 	name    string
-	content []byte // content between BEGIN and END markers, inclusive of markers
-	inner   []byte // content between BEGIN and END markers, exclusive of markers
+	content []byte // content between BEGIN and END markers, inclusive of markers + surrounding newline
+	inner   []byte // content between BEGIN and END markers, exclusive of markers and their trailing newline
 }
 
+// detectEOL returns the dominant line ending of data — CRLF if \r\n occurrences
+// outnumber bare \n occurrences, LF otherwise. Returns LF for empty input.
+func detectEOL(data []byte) []byte {
+	crlf := bytes.Count(data, []byte("\r\n"))
+	lf := bytes.Count(data, []byte("\n")) - crlf
+	if crlf > lf {
+		return []byte("\r\n")
+	}
+	return []byte("\n")
+}
+
+// normalizeEOL converts every line ending in data to target. It first
+// collapses CRLF → LF, then swaps LF → target. This lets renderMarker
+// feed a LF-authored template into CRLF-flavored existing content (and
+// vice versa) without re-implementing split/join on mixed endings.
+func normalizeEOL(data, target []byte) []byte {
+	lf := []byte("\n")
+	crlf := []byte("\r\n")
+	normalized := bytes.ReplaceAll(data, crlf, lf)
+	if bytes.Equal(target, lf) {
+		return normalized
+	}
+	return bytes.ReplaceAll(normalized, lf, target)
+}
+
+// extractSections finds all STEERSPEC:BEGIN/END marker pairs in data by
+// byte offsets. Returns an error on nested, unmatched, or mismatched markers.
+//
+// We match by byte offset rather than line-splitting so mixed line endings
+// (e.g. a previously LF-rendered section inside a now-CRLF file during the
+// CRLF-preservation rollout) don't break marker detection.
 func extractSections(data []byte) ([]section, error) {
-	var sections []section
-	lines := bytes.Split(data, []byte("\n"))
+	begins := markerBeginRe.FindAllSubmatchIndex(data, -1)
+	ends := markerEndRe.FindAllSubmatchIndex(data, -1)
 
-	var current *section
-	var innerLines [][]byte
-	var beginLine []byte
-
-	for _, line := range lines {
-		if m := markerBeginRe.FindSubmatch(line); m != nil {
-			if current != nil {
-				return nil, fmt.Errorf("nested STEERSPEC:BEGIN marker %q inside %q", string(m[1]), current.name)
-			}
-			current = &section{name: string(m[1])}
-			beginLine = line
-			innerLines = nil
-			continue
+	if len(begins) != len(ends) {
+		if len(begins) > len(ends) {
+			name := string(data[begins[len(ends)][2]:begins[len(ends)][3]])
+			return nil, fmt.Errorf("unclosed STEERSPEC:BEGIN marker %q", name)
 		}
-		if m := markerEndRe.FindSubmatch(line); m != nil {
-			name := string(m[1])
-			if current == nil {
-				return nil, fmt.Errorf("STEERSPEC:END marker %q without matching BEGIN", name)
-			}
-			if current.name != name {
-				return nil, fmt.Errorf("STEERSPEC:END marker %q does not match BEGIN %q", name, current.name)
-			}
-			current.inner = bytes.Join(innerLines, []byte("\n"))
-			// Build full content including markers
-			var full bytes.Buffer
-			full.Write(beginLine)
-			full.WriteByte('\n')
-			if len(innerLines) > 0 {
-				full.Write(current.inner)
-				full.WriteByte('\n')
-			}
-			full.Write(line)
-			current.content = full.Bytes()
-			sections = append(sections, *current)
-			current = nil
-			continue
-		}
-		if current != nil {
-			innerLines = append(innerLines, line)
-		}
+		name := string(data[ends[len(begins)][2]:ends[len(begins)][3]])
+		return nil, fmt.Errorf("STEERSPEC:END marker %q without matching BEGIN", name)
 	}
 
-	if current != nil {
-		return nil, fmt.Errorf("unclosed STEERSPEC:BEGIN marker %q", current.name)
-	}
+	sections := make([]section, 0, len(begins))
+	for i, b := range begins {
+		e := ends[i]
+		if e[0] < b[1] {
+			// END appears before BEGIN: unmatched END.
+			name := string(data[e[2]:e[3]])
+			return nil, fmt.Errorf("STEERSPEC:END marker %q without matching BEGIN", name)
+		}
+		if i+1 < len(begins) && begins[i+1][0] < e[0] {
+			// A BEGIN appears before the current END: nested.
+			inner := string(data[begins[i+1][2]:begins[i+1][3]])
+			outer := string(data[b[2]:b[3]])
+			return nil, fmt.Errorf("nested STEERSPEC:BEGIN marker %q inside %q", inner, outer)
+		}
 
+		beginName := string(data[b[2]:b[3]])
+		endName := string(data[e[2]:e[3]])
+		if beginName != endName {
+			return nil, fmt.Errorf("STEERSPEC:END marker %q does not match BEGIN %q", endName, beginName)
+		}
+
+		innerStart, innerEnd := b[1], e[0]
+		inner := trimSurroundingNewline(data[innerStart:innerEnd])
+		content := data[b[0]:e[1]]
+
+		sections = append(sections, section{
+			name:    beginName,
+			inner:   append([]byte(nil), inner...),
+			content: append([]byte(nil), content...),
+		})
+	}
 	return sections, nil
+}
+
+// trimSurroundingNewline strips one leading and one trailing newline (CRLF or
+// LF) from inner marker content so that a round-trip extract/insert doesn't
+// accumulate blank lines across renders.
+func trimSurroundingNewline(b []byte) []byte {
+	if bytes.HasPrefix(b, []byte("\r\n")) {
+		b = b[2:]
+	} else if bytes.HasPrefix(b, []byte("\n")) {
+		b = b[1:]
+	}
+	if bytes.HasSuffix(b, []byte("\r\n")) {
+		b = b[:len(b)-2]
+	} else if bytes.HasSuffix(b, []byte("\n")) {
+		b = b[:len(b)-1]
+	}
+	return b
 }
 
 func renderMarker(templateContent, existingContent []byte) ([]byte, error) {
 	if len(existingContent) == 0 {
 		return templateContent, nil
 	}
+
+	// Preserve the existing file's line ending style so the rendered
+	// result doesn't introduce spurious CRLF/LF churn on Windows-centric
+	// repos. Template content (usually LF-only, as stored in the central
+	// repo) is normalized to the target EOL before section extraction so
+	// the replacement we splice into existing content uses the dominant EOL.
+	eol := detectEOL(existingContent)
+	templateContent = normalizeEOL(templateContent, eol)
 
 	templateSections, err := extractSections(templateContent)
 	if err != nil {
@@ -102,8 +152,8 @@ func renderMarker(templateContent, existingContent []byte) ([]byte, error) {
 			}
 		}
 		if !found {
-			// Section not in existing content; append it
-			result = append(result, '\n')
+			// Section not in existing content; append it with the detected EOL.
+			result = append(result, eol...)
 			result = append(result, ts.content...)
 		}
 	}

--- a/internal/template/render_test.go
+++ b/internal/template/render_test.go
@@ -94,6 +94,113 @@ func TestRenderMarkerEmptyExisting(t *testing.T) {
 	}
 }
 
+// TestRenderMarkerPreservesCRLF verifies that when the existing target file
+// uses CRLF line endings, the rendered output preserves CRLF throughout —
+// including across the section we replaced, the unmanaged preamble/footer,
+// and any newly appended sections. The template itself is authored with LF
+// (the realistic case — templates are stored in the central repo) and must
+// be normalized up to CRLF so marker extraction still finds its sections.
+func TestRenderMarkerPreservesCRLF(t *testing.T) {
+	existing := []byte(strings.Join([]string{
+		"# My File",
+		"Some intro text",
+		"<!-- STEERSPEC:BEGIN:standards -->",
+		"old standards content",
+		"<!-- STEERSPEC:END:standards -->",
+		"Footer text",
+	}, "\r\n"))
+
+	template := []byte(strings.Join([]string{
+		"<!-- STEERSPEC:BEGIN:standards -->",
+		"new standards content",
+		"line two",
+		"<!-- STEERSPEC:END:standards -->",
+	}, "\n"))
+
+	out, err := Render(StrategyMarker, template, existing, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The replaced section's inner content must be present and CRLF-joined.
+	if !bytes.Contains(out, []byte("new standards content\r\nline two")) {
+		t.Errorf("expected CRLF-joined new section body, got %q", string(out))
+	}
+	// Unmanaged preamble and footer must still be CRLF-terminated.
+	if !bytes.Contains(out, []byte("# My File\r\nSome intro text\r\n")) {
+		t.Errorf("preamble lost CRLF, got %q", string(out))
+	}
+	if !bytes.Contains(out, []byte("<!-- STEERSPEC:END:standards -->\r\nFooter text")) {
+		t.Errorf("footer lost CRLF, got %q", string(out))
+	}
+	// No bare LF should have crept in.
+	if bytes.Contains(bytes.ReplaceAll(out, []byte("\r\n"), nil), []byte("\n")) {
+		t.Errorf("output contains stray LF after stripping CRLF: %q", string(out))
+	}
+	if bytes.Contains(out, []byte("old standards content")) {
+		t.Error("old standards content should be replaced")
+	}
+}
+
+// TestRenderMarkerAppendsWithCRLF covers the "section not present in existing"
+// branch at marker.go's append path: the new section must be separated from
+// the existing content with CRLF, not a bare LF.
+func TestRenderMarkerAppendsWithCRLF(t *testing.T) {
+	existing := []byte("# Header\r\nbody line\r\n")
+	template := []byte(strings.Join([]string{
+		"<!-- STEERSPEC:BEGIN:new -->",
+		"brand new content",
+		"<!-- STEERSPEC:END:new -->",
+	}, "\n"))
+
+	out, err := Render(StrategyMarker, template, existing, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The separator between existing and appended section must be CRLF.
+	if !bytes.Contains(out, []byte("body line\r\n\r\n<!-- STEERSPEC:BEGIN:new -->")) {
+		t.Errorf("appended section not separated by CRLF: %q", string(out))
+	}
+	if !bytes.Contains(out, []byte("<!-- STEERSPEC:BEGIN:new -->\r\nbrand new content\r\n<!-- STEERSPEC:END:new -->")) {
+		t.Errorf("appended section body not CRLF-joined: %q", string(out))
+	}
+}
+
+// TestRenderMarkerMixedEndingsPrefersDominant asserts that when existing
+// content has mixed line endings, the dominant style wins.
+func TestRenderMarkerMixedEndingsPrefersDominant(t *testing.T) {
+	// 3 CRLFs vs 1 LF — CRLF wins.
+	existing := []byte("# H\r\na\r\nb\r\n<!-- STEERSPEC:BEGIN:s -->\nold\n<!-- STEERSPEC:END:s -->\r\nfooter")
+	template := []byte("<!-- STEERSPEC:BEGIN:s -->\nnew\n<!-- STEERSPEC:END:s -->")
+
+	out, err := Render(StrategyMarker, template, existing, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Contains(out, []byte("<!-- STEERSPEC:BEGIN:s -->\r\nnew\r\n<!-- STEERSPEC:END:s -->")) {
+		t.Errorf("expected CRLF-joined replacement under dominant CRLF, got %q", string(out))
+	}
+}
+
+// TestRenderMarkerLFRegression locks in that pure-LF existing content keeps
+// LF endings end-to-end (no regression from the CRLF fix).
+func TestRenderMarkerLFRegression(t *testing.T) {
+	existing := []byte("# Header\nbody\n<!-- STEERSPEC:BEGIN:s -->\nold\n<!-- STEERSPEC:END:s -->\nfooter\n")
+	template := []byte("<!-- STEERSPEC:BEGIN:s -->\nnew\n<!-- STEERSPEC:END:s -->")
+
+	out, err := Render(StrategyMarker, template, existing, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bytes.Contains(out, []byte("\r\n")) {
+		t.Errorf("LF-only input should produce LF-only output, got %q", string(out))
+	}
+	if !bytes.Contains(out, []byte("<!-- STEERSPEC:BEGIN:s -->\nnew\n<!-- STEERSPEC:END:s -->")) {
+		t.Errorf("LF replacement missing, got %q", string(out))
+	}
+}
+
 func TestRenderFullReplace(t *testing.T) {
 	tmpl := []byte("This is the template content")
 	existing := []byte("This is existing content that should be ignored")

--- a/internal/template/render_test.go
+++ b/internal/template/render_test.go
@@ -183,6 +183,62 @@ func TestRenderMarkerMixedEndingsPrefersDominant(t *testing.T) {
 	}
 }
 
+// TestExtractSections_NestedBeginReportsOuterAndInner verifies that a BEGIN
+// inside another still-open BEGIN reports the actual outer/inner names — not
+// whichever pair the old count-based shortcut happened to index.
+func TestExtractSections_NestedBeginReportsOuterAndInner(t *testing.T) {
+	data := []byte("<!-- STEERSPEC:BEGIN:a -->\ntext\n<!-- STEERSPEC:BEGIN:b -->\n<!-- STEERSPEC:END:b -->\n<!-- STEERSPEC:END:a -->")
+	_, err := extractSections(data)
+	if err == nil {
+		t.Fatal("expected nesting error")
+	}
+	if !strings.Contains(err.Error(), `nested STEERSPEC:BEGIN marker "b" inside "a"`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestExtractSections_UnclosedOuterReportsOuter verifies the regression
+// Copilot called out: BEGIN A, BEGIN B, END B (A never closed) must point at
+// A as the nesting violation, not at B.
+func TestExtractSections_UnclosedOuterReportsOuter(t *testing.T) {
+	data := []byte("<!-- STEERSPEC:BEGIN:a -->\n<!-- STEERSPEC:BEGIN:b -->\ntext\n<!-- STEERSPEC:END:b -->")
+	_, err := extractSections(data)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// The first violation is the inner BEGIN inside the still-open outer.
+	if !strings.Contains(err.Error(), `nested STEERSPEC:BEGIN marker "b" inside "a"`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestExtractSections_EndBeforeBeginReportsEnd verifies that an END that
+// appears before any BEGIN is flagged with the offending END's name (not
+// a stale BEGIN from further down).
+func TestExtractSections_EndBeforeBeginReportsEnd(t *testing.T) {
+	data := []byte("<!-- STEERSPEC:END:stray -->\n<!-- STEERSPEC:BEGIN:real -->\n<!-- STEERSPEC:END:real -->")
+	_, err := extractSections(data)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `STEERSPEC:END marker "stray" without matching BEGIN`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestExtractSections_UnclosedBeginReportsName verifies the simple single-BEGIN
+// unclosed case points at the right name.
+func TestExtractSections_UnclosedBeginReportsName(t *testing.T) {
+	data := []byte("<!-- STEERSPEC:BEGIN:only -->\ntext")
+	_, err := extractSections(data)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `unclosed STEERSPEC:BEGIN marker "only"`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 // TestRenderMarkerLFRegression locks in that pure-LF existing content keeps
 // LF endings end-to-end (no regression from the CRLF fix).
 func TestRenderMarkerLFRegression(t *testing.T) {


### PR DESCRIPTION
## Summary

- `internal/template/marker.go` now preserves the dominant line-ending style of the existing target file instead of hard-coding LF. On Windows-centric repos this eliminates the CRLF→LF churn that was making every sync PR noisy.
- Templates stored in the central repo (typically LF-only) are normalized to the target EOL before being spliced into existing content, so marker matching still works regardless of the template's own style.
- `extractSections` is rewritten to find BEGIN/END markers by regex byte-offset rather than line-splitting. This makes it robust to **mixed** endings inside a file — the realistic transition case where a previously LF-rendered section lives inside a now-CRLF file during this fix's rollout.
- New tests cover CRLF round-trip replacement, CRLF tail-append, mixed-endings preferring the dominant style, and a pure-LF regression lock.

Closes #19. Task 2 of Phase 4 operational polish (beads epic `strspc-sync-11g`, task `strspc-sync-4rv`).

## ⚠️ One-time hash drift on upgrade

`internal/hash/blake3.go:HashBytes` is byte-exact. Target repos whose files use CRLF have been previously rendered by marker as LF-only; their stored deployment-state hashes reflect that. After this fix:

- The next `strspc monitor` run will rehash the target and see CRLF where the stored hash is LF → **drift issue filed**.
- Running `strspc sync` once resolves it — the new render is already byte-correct, so the subsequent monitor run matches.

**Why not normalize at hash time?** That would be a larger architectural change affecting all strategies (not just marker), and would introduce its own migration story. A one-time, self-healing drift on affected repos only is the smaller blast radius.

Operators should expect exactly one round of post-upgrade drift issues on CRLF repos, followed by stability.

## Test plan

- [x] `go test -race ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `TestRenderMarkerPreservesCRLF` — end-to-end CRLF round-trip on replacement
- [x] `TestRenderMarkerAppendsWithCRLF` — CRLF used when a new section is appended
- [x] `TestRenderMarkerMixedEndingsPrefersDominant` — mixed-ending input resolves via dominant style (and the rewritten byte-offset extractor handles it without splitting)
- [x] `TestRenderMarkerLFRegression` — LF-only input produces LF-only output (no CRLF leakage)
- [x] Existing marker tests (`TestRenderMarkerReplacesSection`, `TestRenderMarkerNoExisting`, `TestRenderMarkerEmptyExisting`) still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)